### PR TITLE
Get updates from main into the bump branch

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,19 @@
+name: Build and Test
+
+on:
+  issue_comment:
+    types:
+      - created
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - 'cicd*.groovy'
+      - '**/LICENSE'
+      - 'README.md'
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    if: (github.event.issue.pull_request && contains(github.event.comment.body, '/run tests')) || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request_target'
+    uses: ZOSOpenTools/meta/.github/workflows/build_and_test.yml@main
+    secrets: inherit

--- a/buildenv
+++ b/buildenv
@@ -19,8 +19,8 @@ export ZOPEN_CLEAN="zopen_clean"
 zopen_init()
 {
   export CGO_ENABLED=0
-  export GOTMPDIR=$HOME/go-tmpdir
-  mkdir -p $HOME/go-tmpdir
+  export GOTMPDIR=$PWD/go-tmpdir
+  mkdir -p $PWD/go-tmpdir
   export PATH=$PATH:$GOROOT/go-build-zos/bin
   export GOBIN=$ZOPEN_INSTALL_DIR/bin
   mkdir -p $ZOPEN_INSTALL_DIR/bin


### PR DESCRIPTION
Not sure if I'm doing this right, do close if it's wrong.
Goal is to get main's commits into bump's branch, so that [this commit](https://github.com/ZOSOpenTools/gitlab-runnerport/commit/93acdf0fb5f79d5982505df557ad0fdb5b396d5c) is included.
It helps get past the build error currently seen in the bump branch.